### PR TITLE
feat: Add support for synchronous updates without async/await

### DIFF
--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -159,7 +159,7 @@ export function atom<T, S = T, U = T>({
 export function useAtom<T, S = T>(atom: Atom<T, S>): [T, (value: S) => void] {
   const [data, setData] = useState<T>(atom.subject.value);
 
-  const update = useCallback((value: S) => atom.update(value), [atom]);
+  const update = useCallback((value: S) => atom.update(value), []);
 
   useEffect(() => {
     return atom.subject.subscribe(setData);

--- a/lib/atoms.ts
+++ b/lib/atoms.ts
@@ -11,6 +11,7 @@ type ConcurrencyNoSync = "queue" | "throttle" | "debounce";
 export function atom<T, S = T, U = T>({
   initialValue,
   persistKey,
+  persistLayer,
   update,
   appVersion,
   transformOnDeserialize,
@@ -21,6 +22,7 @@ export function atom<T, S = T, U = T>({
 }: {
   initialValue: T;
   persistKey?: string;
+  persistLayer?: "local" | "session";
   update?: (state: T, value: S) => T;
   appVersion?: string;
   transformOnSerialize?: (obj: T) => U | Promise<U>;
@@ -32,6 +34,7 @@ export function atom<T, S = T, U = T>({
 export function atom<T, S = T, U = T>({
   initialValue,
   persistKey,
+  persistLayer,
   update,
   appVersion,
   transformOnDeserialize,
@@ -42,6 +45,7 @@ export function atom<T, S = T, U = T>({
 }: {
   initialValue: T;
   persistKey?: string;
+  persistLayer?: "local" | "session";
   update?: (state: T, value: S) => Promise<T> | T;
   appVersion?: string;
   transformOnSerialize?: (obj: T) => U | Promise<U>;
@@ -53,6 +57,7 @@ export function atom<T, S = T, U = T>({
 export function atom<T, S = T, U = T>({
   initialValue,
   persistKey,
+  persistLayer,
   update,
   appVersion,
   transformOnDeserialize,
@@ -63,6 +68,7 @@ export function atom<T, S = T, U = T>({
 }: {
   initialValue: T;
   persistKey?: string;
+  persistLayer?: "local" | "session";
   update?: (state: T, value: S) => T;
   appVersion?: string;
   transformOnSerialize?: (obj: T) => U | Promise<U>;
@@ -74,6 +80,7 @@ export function atom<T, S = T, U = T>({
 export function atom<T, S = T, U = T>({
   initialValue,
   persistKey,
+  persistLayer = "local",
   update,
   appVersion,
   transformOnDeserialize,
@@ -84,6 +91,7 @@ export function atom<T, S = T, U = T>({
 }: {
   initialValue: T;
   persistKey?: string;
+  persistLayer?: "local" | "session";
   update?: (state: T, value: S) => Promise<T> | T;
   appVersion?: string;
   transformOnSerialize?: (obj: T) => U | Promise<U>;
@@ -100,12 +108,13 @@ export function atom<T, S = T, U = T>({
   let initPersistanceIsRunning = false;
 
   if (persistKey) {
+    const storage = persistLayer === 'local' ? localStorage : sessionStorage;
     // Load from storage after the atom is created
-    const storedJson = JSON.parse(localStorage.getItem(persistKey) ?? "{}");
+    const storedJson = JSON.parse(storage.getItem(persistKey) ?? "{}");
 
     // Remove from storage if version has been updated
     if (storedJson.version !== appVersion) {
-      localStorage.removeItem(persistKey);
+      storage.removeItem(persistKey);
     } else if (transformOnDeserialize && storedJson.data) {
       let deserialized = transformOnDeserialize(storedJson.data);
       if (isPromise(deserialized)) {
@@ -141,7 +150,7 @@ export function atom<T, S = T, U = T>({
             data = await data;
           }
         }
-        localStorage.setItem(
+        storage.setItem(
           persistKey,
           JSON.stringify({ data, version: appVersion }),
         );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ximple",
-    "version": "2.6.5",
+    "version": "2.6.6",
     "description": "Simple event and atomic state library inspired by RxJS, Recoil and Jotai",
     "main": "dist/index.js",
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ximple",
-    "version": "2.6.6",
+    "version": "2.6.7",
     "description": "Simple event and atomic state library inspired by RxJS, Recoil and Jotai",
     "exports": { ".": "./lib/index.ts", "./atoms": "./lib/atoms.ts" },
     "type": "module",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "ximple",
     "version": "2.6.6",
     "description": "Simple event and atomic state library inspired by RxJS, Recoil and Jotai",
-    "main": "dist/index.js",
+    "exports": { ".": "./lib/index.ts", "./atoms": "./lib/atoms.ts" },
     "type": "module",
     "scripts": {
         "build": "tsc",


### PR DESCRIPTION
I added a new `concurrency` type named `synchronous` to `atom()`, and made it the new default behavior.
With this type there is no async behavior involved when setting the state.
I also added function-overloads to give typescript errors if you try to set an async function as the `update` when using `synchronous` concurrency.

This way it will play more nicely with the react-lifecycle, and in most case this is what you want when utilizing the library with react.

The reason this was needed is because currently form-inputs "break" when you use atom-values directly in inputs, and the effect is that react will loose the cursor position in the input element and jump the cursor to the end of the input-value instead of preserving the cursor position after something is typed in.

As an example, something simple like this is enough to illustrate the breakage, effectively making atom unusable for state used in inputs:
```tsx
import { atom, useAtom } from 'ximple';

const testAtom = atom({ initialValue: '', concurrency: 'queue' });

function App() {
  const [test, setTest] = useAtom(testAtom);

  return (
    <>
      <input
          type="text"
          value={test}
          onChange={(e) => { setTest(e.currentTarget.value) }}
      />
    </>
  )
}

export default App
```

Here is a recording to show the cursor jumping:
https://github.com/user-attachments/assets/c5e8635b-2348-4749-ac5c-53a9bc1ca41c

